### PR TITLE
removed leftover

### DIFF
--- a/builds/bundle.js
+++ b/builds/bundle.js
@@ -92308,7 +92308,6 @@
 				schema.editor = schema.editor || {};
 				var doc = id == 'create' ? undefined : results[1].data;
 				this.doc = doc;
-				schema.format = schema.format || "grid";
 				this.editor = new JSONEditor(this.refs.editor, Object.assign({
 					schema: schema,
 					theme: 'bootstrap3',

--- a/src/JSON_Editor.js
+++ b/src/JSON_Editor.js
@@ -23,7 +23,6 @@ var JSON_Editor = React.createClass({
 			schema.editor = schema.editor || {}
 			var doc = (id == 'create') ? undefined : results[1].data;
 			this.doc = doc;
-			schema.format = schema.format || "grid"
 			this.editor = new JSONEditor(this.refs.editor, Object.assign({
 				schema: schema,
 				theme: 'bootstrap3',


### PR DESCRIPTION
this is not needed anymore since we can configure json-editor using the `editor`-field in the json-schema.